### PR TITLE
Fix sparkgeo accidentally removed from sponsor page. Fixes #91

### DIFF
--- a/src/lib/sponsors.ts
+++ b/src/lib/sponsors.ts
@@ -6,7 +6,7 @@ export const LEVELS = {
   VENUE: 4,
   PARTNER: 5,
   SUPPORTER: 6,
-  CHILDCARE: 10,
+  CHILDCARE: 10
 };
 
 export default {
@@ -58,17 +58,23 @@ export default {
     link: 'https://qfield.cloud/',
     level: LEVELS.SILVER
   },
+  sparkgeo: {
+    name: 'SparkGEO',
+    logo: () => import('$images/logos/sparkgeo.png?enhanced'),
+    link: 'https://sparkgeo.com/',
+    level: LEVELS.SILVER
+  },
+  sparkgeochildcare: {
+    name: 'SparkGEO-Childcare',
+    logo: () => import('$images/logos/sparkgeo.png?enhanced'),
+    link: 'https://sparkgeo.com/',
+    level: LEVELS.CHILDCARE
+  },
   sotm2025: {
     name: 'SOTM2025',
     logo: () => import('$images/logos/sotm2025.png?enhanced'),
     link: 'https://2025.stateofthemap.org/',
     level: LEVELS.SUPPORTER
-  },
-  sparkgeo: {
-    name: 'SparkGEO',
-    logo: () => import('$images/logos/sparkgeo.png?enhanced'),
-    link: 'https://sparkgeo.com/',
-    level: LEVELS.SILVER + LEVELS.CHILDCARE
   },
   tomtom: {
     name: 'TomTom',


### PR DESCRIPTION
Now displayed correctly:

<img width="793" alt="Screenshot 2025-07-04 at 9 29 33 AM" src="https://github.com/user-attachments/assets/d4aaee33-c0e0-465b-b09d-884114314eac" />
