### PR TITLE
Fix Call for Papers countdown

### DIFF
--- a/src/routes/attend/call-for-papers/+page.svx
+++ b/src/routes/attend/call-for-papers/+page.svx
@@ -18,7 +18,7 @@ title: Call for Papers
 
 <main class="my-4 space-y-5">
 
-<Countdown label="Call For Papers ends in:" time="2025-07-11T00:00:00" />
+<Countdown label="Call For Papers ends in:" time="2025-07-12T00:00:00" />
 
 
 <!-- Cards -->


### PR DESCRIPTION
It was counting down to the beginning of the last day for submissions rather than the end of that day.