### PR TITLE
Adds the foss4g 2025 welcome video to the home page

### DIFF
--- a/src/components/Video.svelte
+++ b/src/components/Video.svelte
@@ -16,9 +16,12 @@
 <style>
   .video-container {
     position: relative;
-    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    padding-bottom: 57%; /* 16:9 aspect ratio */
     padding-top: 25px;
     height: 0;
+    border-radius: 25px;
+    overflow: hidden;
+    z-index: 1;
   }
   .video-container iframe {
     position: absolute;

--- a/src/components/Video.svelte
+++ b/src/components/Video.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  let { src = null } = $props();
+</script>
+
+<div class="video-container">
+  <iframe
+    title="YouTube video player"
+    {src}
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<style>
+  .video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    padding-top: 25px;
+    height: 0;
+  }
+  .video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,8 @@
   import Sponsors, { LEVELS as SPONSOR_LEVELS } from '$lib/sponsors';
   import Team from '$lib/organisers';
   import Button from '$components/Button.svelte';
-  import Card from '../components/Card.svelte';
+  import Card from '$components/Card.svelte';
+  import Video from '$components/Video.svelte';
   import News from '$lib/news';
 
   const whyAttends = [
@@ -215,6 +216,10 @@
         </div>
       </Card>
     </div>
+  </div>
+
+  <div>
+    <Video src="https://www.youtube-nocookie.com/embed/HNxqnUhL-yM?si=Z5-6exzf98KhoHZy" />
   </div>
 
   <Heading>Agenda</Heading>


### PR DESCRIPTION
Fixes #119


<img width="330" height="781" alt="Screenshot 2025-07-17 at 5 45 58 PM" src="https://github.com/user-attachments/assets/bd8461ee-3d42-44df-ab9e-7bac281a4a93" />
