### PR TITLE
Fix timezone of date headers in schedule fixes #176

### DIFF
--- a/src/components/BetterSchedule.svelte
+++ b/src/components/BetterSchedule.svelte
@@ -120,10 +120,12 @@
   }
 
   function formatDate(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString('en-US', {
+    const date = new Date(dateStr + 'T00:00:00+13:00');
+    return date.toLocaleDateString('en-US', {
       weekday: 'short',
       month: 'long',
-      day: 'numeric'
+      day: 'numeric',
+      timeZone: 'Pacific/Auckland'
     });
   }
 
@@ -207,7 +209,7 @@
           days = cachedData.days;
 
           // Set active day to today or first day
-          const today = new Date().toISOString().split('T')[0];
+          const today = new Date().toLocaleDateString('en-US', { timeZone: 'Pacific/Auckland' });
           const todayIndex = days.findIndex((day: any) => day.date === today);
           activeDay = todayIndex >= 0 ? todayIndex : 0;
 
@@ -231,7 +233,7 @@
       setCachedData({ version, conference, days });
 
       // Set active day to today or first day
-      const today = new Date().toISOString().split('T')[0];
+      const today = new Date().toLocaleDateString('sv-SE', { timeZone: 'Pacific/Auckland' });
       const todayIndex = days.findIndex((day: any) => day.date === today);
       activeDay = todayIndex >= 0 ? todayIndex : 0;
 
@@ -434,7 +436,8 @@
             <span class="sm:hidden"
               >{new Date(day.date).toLocaleDateString('en-US', {
                 weekday: 'short',
-                day: 'numeric'
+                day: 'numeric',
+                timeZone: 'Pacific/Auckland'
               })}</span
             >
           </button>


### PR DESCRIPTION
Day headers in the schedule were incorrectly shuffled to the users browser timezone - this change fixes the TZ handling and ensures the right days are shown.

<img width="1243" height="1037" alt="Screenshot 2025-09-19 at 8 28 18 AM" src="https://github.com/user-attachments/assets/ca82b439-7a1c-48b9-8d85-e0b64f5f1652" />


Refer https://github.com/osgeo-oceania/foss4g-2025/issues/176 - thanks @awstalldave