### PR TITLE
update workshops, close volunteer EOI, update news

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -85,8 +85,8 @@
           url: '/attend/nz-adventures'
         },
         {
-          label: 'Accomodation',
-          url: '/attend/accomodation'
+          label: 'Accommodation',
+          url: '/attend/accommodation'
         }
       ]
     },

--- a/src/components/TicketOptions.svelte
+++ b/src/components/TicketOptions.svelte
@@ -3,7 +3,7 @@
 
   const ticketOptions = [
     {
-      title: 'Standard Conference Ticket',
+      title: 'Last Chance Conference Ticket',
       description:
         'Includes full conference registration for Wednesday 19th, Thursday 20th and Friday 21st November as well as access to the icebreaker on Tuesday night.',
       price: '$1250',

--- a/src/lib/news.ts
+++ b/src/lib/news.ts
@@ -1,5 +1,27 @@
 export default [
   {
+    date: '3rd October 2025',
+    title: 'Standard Pricing ends today',
+    content: `
+Standard pricing ends today.
+
+Jumping from $950 to $1250 NZD tomorrow.
+`,
+    link: 'https://us14.campaign-archive.com/?u=b871212546ebe0a91f640e01f&id=a52070e1ad'
+  },
+  {
+    date: '22nd September 2025',
+    title: 'The program is live + short extension of standard pricing and TGP',
+    content: `
+We've extended standard pricing for 2 weeks.
+
+Round 2 of the Travel Grant Program is also extended.
+
+The full week-long program is live!
+`,
+    link: 'https://us14.campaign-archive.com/?u=b871212546ebe0a91f640e01f&id=2fb2c17cd0'
+  }, 
+  {
     date: '9th September 2025',
     title: 'Announcing keynotes and workshops + round 2 of travel grants',
     content: `

--- a/src/routes/attend/accomodation/+page.svx
+++ b/src/routes/attend/accomodation/+page.svx
@@ -1,9 +1,9 @@
 ---
-title: Accomodation
+title: Accommodation
 ---
 
 <svelte:head>
-  <title>Accomodation</title>
+  <title>Accommodation</title>
 </svelte:head>
 
 <script lang="ts">
@@ -11,9 +11,9 @@ title: Accomodation
   import Link from '$components/Link.svelte';
 </script>
 
-<Heading>Accomodation</Heading>
+<Heading>Accommodation</Heading>
 
-Auckland has a wide range of accomodation options, from 5-star hotels, to backpackers and vacation rental houses.
+Auckland has a wide range of accommodation options, from 5-star hotels, to backpackers and vacation rental houses.
 
 ### Conference Discounts
 

--- a/src/routes/attend/register/+page.svx
+++ b/src/routes/attend/register/+page.svx
@@ -37,8 +37,8 @@ It also includes access to the Icebreaker on Tuesday 18th November and the Commu
 | Type                  | Details                                                                                                                   | Cost (NZD) |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | ~~Early Bird~~        | ~~Early bird registration, available until 18th July (NZT).~~                                                             | ~~$700~~   |
-| Standard              | General registration, available from 19th July until 20th September.                                                      | $950       |
-| Last Chance           | Last minute registration after 20th September.                                                                            | $1250      |
+| ~~Standard~~          | ~~General registration, available from 19th July until 3rd October.~~                                                      | $950       |
+| Last Chance           | Last minute registration after 3rd October.                                                                            | $1250      |
 | True Believer         | Also includes a dinner ticket and a contribution to the Travel Grant Program.                                             | $1950      |
 | Student/Retired       | For secondary and tertiary students at any institution, and for people who are no longer in paid work.                    | $500       |
 | Community Contributor | For open source, open data or volunteer community contributors otherwise not supported by another organisation to attend. | $500       |

--- a/src/routes/attend/volunteering/+page.svx
+++ b/src/routes/attend/volunteering/+page.svx
@@ -15,7 +15,8 @@ title: Volunteering
 
 ![Auckland]($images/group-photo.jpg)
 
-
+## Expression of interest details
+**The expression of interest for volunteers has now closed.**
 
 ## Who can volunteer?
 Anyone who would like to attend can volunteer!
@@ -36,9 +37,3 @@ We have a range of perks to offer you for your help during our conference includ
 - Expand your knowledge and expertise in the field, and interact with other industry experts.
 - When not on duty, enjoy free access to the full conference experience, including over 100 insightful talks and 44 hands-on workshops.
 
-## Expression of interest details
-If you’ve made it this far, you must be interested! 
-
-Please [fill in this form](https://docs.google.com/forms/d/e/1FAIpQLSfhAuBfrJKc5GpUHecQ4dgxMP_LF0VuTPG-PuSXUzaAMFV3Sg/viewform?usp=sharing&ouid=110063076206005231651), and we will be in touch. 
-
-You’ll then be sent a link closer to the conference to sign up for further registration including food allergies and shirt sizing, and will be invited to the group chat used to communicate throughout the conference.

--- a/src/routes/program/workshops/+page.svx
+++ b/src/routes/program/workshops/+page.svx
@@ -31,7 +31,6 @@ There will be catering on these days for workshop participants only.
 • [Hands-on DGGS and OGC DGGS-API with DGGRID and pydggsapi Workshop](https://talks.osgeo.org/foss4g-2025/talk/AGFBHA/)<br>
 • [Introduction to GeoServer Workshop](https://talks.osgeo.org/foss4g-2025/talk/H7LS7U/)<br>
 • [Let’s create Interactive Web Maps with the Open-Source WebGIS: Re:Earth - Visualizer + Re:Earth CMS Workshop](https://talks.osgeo.org/foss4g-2025/talk/RQLV9M/)<br>
-• [Microwave Image Processing: Exploring realms of Earth through spaceborne Radars using Python Workshop](https://talks.osgeo.org/foss4g-2025/talk/EQTRSA/)<br>
 • [QField & QFieldCloud: Hands-On Fieldwork Workshop](https://talks.osgeo.org/foss4g-2025/talk/BJJF7M/)
 
 <GiantButton href="https://ti.to/osgeo-oceania/foss4g-2025/">
@@ -43,7 +42,6 @@ There will be catering on these days for workshop participants only.
 1:30pm to 5:00pm
 
 **You will be able to choose one of the following after purchase:**<br>
-• [Achieving Reproducibility in Geospatial Data Processing with Apache Airflow Workshop](https://talks.osgeo.org/foss4g-2025/talk/VTVQQL/)<br>
 • [Cartography for Rebels: Building Beautiful Maps with Free Tools Workshop](https://talks.osgeo.org/foss4g-2025/talk/RUVQSJ/)<br>
 • [Doing Geospatial with Python Workshop](https://talks.osgeo.org/foss4g-2025/talk/XD8Z8K/)<br>
 • [Exploring Cloud-Native Geospatial Formats: Hands-on with Raster Data Workshop](https://talks.osgeo.org/foss4g-2025/talk/KZGHTZ/)<br>
@@ -73,7 +71,7 @@ There will be catering on these days for workshop participants only.
 • [Modelling Climate Risks Using NASA Earthdata Cloud & Python APIs Workshop](https://talks.osgeo.org/foss4g-2025/talk/QTAWL7/)<br>
 • [Oxidize to Decarbonize. Building more sustainable geospatial processes with Rust Workshop](https://talks.osgeo.org/foss4g-2025/talk/RDZMQP/)<br>
 • [pgRouting basic Workshop](https://talks.osgeo.org/foss4g-2025/talk/FGATAY/)<br>
-• [PMTiles for Hobbyists: An Introduction Workshop](https://talks.osgeo.org/foss4g-2025/talk/BMWWR9/)<br>
+• [Standalone Web Maps, No Platform Required Workshop](https://talks.osgeo.org/foss4g-2025/talk/BMWWR9/)<br>
 • [Terra Draw - cross-platform drawing library for all map applications Workshop](https://talks.osgeo.org/foss4g-2025/talk/7S9CLN/)
 
 <GiantButton href="https://ti.to/osgeo-oceania/foss4g-2025/">


### PR DESCRIPTION
- Removed 2x workshops that are no longer being offered and renamed 1 that was renamed by the presenter
- Added a note that volunteer expressions of interest are closed and removed the Google Forms link
- Added two recent news items from Mailchimp
- Updated "Standard" to "Last Chance" and striked out the standard conference ticket from the ticket options list
- Updated accomodation -> accommodation (typo)