### PR TITLE
Add detailed Rangitoto trip information, tweak all event pages

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -111,8 +111,28 @@
           url: '/program/events'
         },
         {
+          label: '- Movie Screening',
+          url: '/program/movie-screening'
+        },
+        {
           label: '- B2B Event',
           url: '/program/b2b-event'
+        },
+        {
+          label: '- Ice Breaker',
+          url: '/program/ice-breaker'
+        },
+        {
+          label: '- Travel Grant Breakfast',
+          url: '/program/travel-grant-breakfast'
+        },
+        {
+          label: '- Gala Dinner',
+          url: '/program/gala-dinner'
+        },
+        {
+          label: '- GeoChicas',
+          url: '/program/geochicas'
         },
         {
           label: '- Rangitoto Day Trip',

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -111,11 +111,15 @@
           url: '/program/events'
         },
         {
-          label: 'B2B Event',
+          label: '- B2B Event',
           url: '/program/b2b-event'
         },
         {
-          label: 'Community Events and Code Sprints',
+          label: '- Rangitoto Day Trip',
+          url: '/program/rangitoto'
+        },
+        {
+          label: '- Community Events and Code Sprints',
           url: '/program/community-day'
         }
       ]
@@ -129,7 +133,7 @@
 
 <div
   class:sm:scale-75={page.route.id == '/map'}
-  class="navbar border-primary/10 sticky top-0 z-20 h-16 border-b-1 bg-white px-4 rounded-lg py-2 sm:relative sm:top-auto sm:h-22 sm:border-none sm:py-6"
+  class="navbar border-primary/10 sticky top-0 z-20 h-16 rounded-lg border-b-1 bg-white px-4 py-2 sm:relative sm:top-auto sm:h-22 sm:border-none sm:py-6"
 >
   <div class="navbar-start z-20 my-4 w-auto">
     <Link href="/"><img src={LogoText} alt="FOSS4G Logo" class="-ml-3.5 max-w-[220px]" /></Link>

--- a/src/routes/program/events/+page.svx
+++ b/src/routes/program/events/+page.svx
@@ -21,17 +21,15 @@ title: Events
 
 We're excited to offer a range of supporting events around this years conference.
 
-### Movie screening
+### [Movie Screening](/program/movie-screening)
 
 Monday 17th November, 6pm
 
 A free movie screening held at the AUT conference centre, room WG403.
 
-**I am the River, the River is Me**
+**I am the River, the River is Me** - A powerful documentary exploring Māori perspectives on environmental stewardship and the revolutionary legal recognition of the Whanganui River as a living entity.
 
-> A canoe trip down the Whanganui River in New Zealand, led by a Māori elder, awakens 
-> spiritual belief and practice, and becomes a call to action to draw closer to nature 
-> and fight climate change through a fundamental value shift.
+[Learn more →](/program/movie-screening)
 
 
 ### [Business 2 Business](/program/b2b-event)
@@ -42,35 +40,37 @@ An afternoon session of networking over canapes and drinks with brief talks from
 
 [Learn more and purchase tickets →](/program/b2b-event)
 
-### Ice Breaker
+### [Ice Breaker](/program/ice-breaker)
 
-Tuesday 18th November from 6.30pm
+Tuesday 18th November from 6:30pm
 
 Our Ice Breaker event will be held at the Maritime Room, New Zealand Maritime Museum, Corner of Quay and Hobson Street, Auckland.
 
-This is a relaxed event to meet your fellow delegates over canapes and drinks.
+Start your FOSS4G experience by connecting with fellow attendees over canapes and drinks in this relaxed waterfront venue.
+
+[Learn more →](/program/ice-breaker)
 
 <enhanced:img src={MaritimeRoom} alt="Maritime Room View" />
 
-### Travel Grant Program Breakfast
+### [Travel Grant Program Breakfast](/program/travel-grant-breakfast)
 
 Wednesday 19th November - Morning
 
-Held at Scarecrow
+A special breakfast gathering for Travel Grant recipients at Scarecrow, 33 Victoria Street East, Auckland Central.
 
-33 Victoria Street East, Auckland Central
+This exclusive event is an opportunity to meet fellow grant awardees and connect with the FOSS4G organizing team.
 
-This event is available to our Travel Grant recipients.
+[Learn more →](/program/travel-grant-breakfast)
 
-### Gala Dinner
+### [Gala Dinner](/program/gala-dinner)
 
 Wednesday 19th November - Evening
 
-Our gala dinner is at the Hilton, Auckland. Join the community in celebrating FOSS4G over dinner and live music.
+Join the global FOSS4G community for an unforgettable evening of celebration at the Hilton Auckland. Enjoy fine dining, live music, and spectacular waterfront views.
 
 147 Quay Street, Auckland Central
 
-[Purchase Tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/conference-dinner)
+[Learn more and purchase tickets →](/program/gala-dinner)
 
 ### Women in Spatial Breakfast
 
@@ -80,13 +80,15 @@ Thursday 20th November – Morning
 
 *Tickets are sold out!* [Join Waitlist →](https://ti.to/osgeo-oceania/foss4g-2025/with/women-in-geospatial-breakfast)
 
-### GeoChicas
+### [GeoChicas](/program/geochicas)
 
 Thursday 20th November – Evening
 
+Join GeoChicas, the international women's collective focused on closing gender gaps in the OpenStreetMap and open geospatial communities, for an evening of networking and community building.
+
 Held at RocketMan, 8 Roukai Lane, Auckland Central
 
-[Pay what you want for tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/geochickas)
+[Learn more and get tickets →](/program/geochicas)
 
 ### [Rangitoto Island Day Trip](/program/rangitoto)
 

--- a/src/routes/program/events/+page.svx
+++ b/src/routes/program/events/+page.svx
@@ -88,10 +88,12 @@ Held at RocketMan, 8 Roukai Lane, Auckland Central
 
 [Pay what you want for tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/geochickas)
 
-### Rangitoto Island Day Trip
+### [Rangitoto Island Day Trip](/program/rangitoto)
 
 Saturday 22nd November – All Day (weather permitting)
 
-Watch this space!
+Join fellow FOSS4G attendees for an unforgettable outdoor adventure to Rangitoto Island, Auckland's iconic volcanic cone! This is a perfect opportunity to connect with the community while exploring one of New Zealand's most unique natural landmarks, with breathtaking 360-degree views of Auckland and the Hauraki Gulf from the summit.
+
+See [Rangitoto Day Trip](/program/rangitoto) for more information and to purhcase tickets.
 
 <enhanced:img src={Rangitoto} alt="Rangitoto Island" />

--- a/src/routes/program/gala-dinner/+page.svx
+++ b/src/routes/program/gala-dinner/+page.svx
@@ -1,0 +1,42 @@
+---
+title: Gala Dinner
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+  import Dinner from '$images/conference-dinner-2023.png?enhanced';
+  import Button from '$components/Button.svelte';
+</script>
+
+<enhanced:img src={Dinner} />
+
+<div class="flex flex-row justify-between">
+<Heading>Gala Dinner</Heading>
+<Button class="w-50" href="https://ti.to/osgeo-oceania/foss4g-2025/with/conference-dinner">Purchase Tickets</Button>
+</div>
+
+**Wednesday 19th November - Evening**
+
+Join the global FOSS4G community for an unforgettable evening of celebration, connection, and entertainment at our Gala Dinner. This is the highlight social event of the conference, bringing together attendees from around the world for an evening of fine dining, live music, and celebration of our shared passion for open source geospatial technology.
+
+## Venue
+
+Hilton Auckland
+147 Quay Street
+Auckland Central
+
+The Hilton Auckland offers spectacular waterfront views and world-class dining facilities, providing the perfect setting for our gala celebration.
+
+## What to Expect
+
+- **Exceptional Dining**: Enjoy a multi-course dinner prepared by the Hilton's culinary team
+- **Live Music**: Dance and enjoy live entertainment throughout the evening
+- **Networking**: Connect with colleagues and friends from the global geospatial community
+- **Celebration**: Toast to another successful FOSS4G conference
+- **Stunning Views**: Take in Auckland's waterfront ambiance from one of the city's premier venues
+
+The Gala Dinner is a highlight of every FOSS4G conference - an opportunity to celebrate our community's achievements, forge new friendships, and create lasting memories with fellow open source enthusiasts from around the world.
+
+Don't miss this special evening!
+
+[Purchase Tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/conference-dinner)

--- a/src/routes/program/gala-dinner/+page.svx
+++ b/src/routes/program/gala-dinner/+page.svx
@@ -15,7 +15,7 @@ title: Gala Dinner
 <Button class="w-50" href="https://ti.to/osgeo-oceania/foss4g-2025/with/conference-dinner">Purchase Tickets</Button>
 </div>
 
-**Wednesday 19th November - Evening**
+**Wednesday 19th November - 6pm until late**
 
 Join the global FOSS4G community for an unforgettable evening of celebration, connection, and entertainment at our Gala Dinner. This is the highlight social event of the conference, bringing together attendees from around the world for an evening of fine dining, live music, and celebration of our shared passion for open source geospatial technology.
 
@@ -30,10 +30,11 @@ The Hilton Auckland offers spectacular waterfront views and world-class dining f
 ## What to Expect
 
 - **Exceptional Dining**: Enjoy a multi-course dinner prepared by the Hilton's culinary team
-- **Live Music**: Dance and enjoy live entertainment throughout the evening
+- **Live Music & Dancing**: Dance the night away to live music from **Wolves and Ravens** on our dedicated dance floor
+- **Inspiring Speakers**: Hear from local GIS legend **Kim Ollivier** about his experiences in the geospatial industry, and from **Rua Puka**, our talented logo designer, about the story behind the FOSS4G 2025 conference logo
 - **Networking**: Connect with colleagues and friends from the global geospatial community
 - **Celebration**: Toast to another successful FOSS4G conference
-- **Stunning Views**: Take in Auckland's waterfront ambiance from one of the city's premier venues
+- **Stunning Views**: Take in amazing views of Auckland's harbour and city skyline from one of the waterfront's premier venues
 
 The Gala Dinner is a highlight of every FOSS4G conference - an opportunity to celebrate our community's achievements, forge new friendships, and create lasting memories with fellow open source enthusiasts from around the world.
 

--- a/src/routes/program/geochicas/+page.svx
+++ b/src/routes/program/geochicas/+page.svx
@@ -1,0 +1,43 @@
+---
+title: GeoChicas
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+  import Button from '$components/Button.svelte';
+</script>
+
+<div class="flex flex-row justify-between">
+<Heading>GeoChicas</Heading>
+<Button class="w-50" href="https://ti.to/osgeo-oceania/foss4g-2025/with/geochickas">Get Tickets</Button>
+</div>
+
+**Thursday 20th November - Evening**
+
+Join GeoChicas, the international women's collective focused on closing gender gaps in the OpenStreetMap and open geospatial communities, for an evening of networking, sharing, and community building.
+
+## Venue
+
+RocketMan
+8 Roukai Lane
+Auckland Central
+
+RocketMan is a vibrant bar in central Auckland, offering a relaxed and welcoming atmosphere perfect for community gathering and conversation.
+
+## About GeoChicas
+
+GeoChicas is a women's group within the OpenStreetMap and broader geospatial communities, working to increase the participation and visibility of women in these spaces. This gathering provides an opportunity to:
+
+- Connect with women and allies in the geospatial community
+- Share experiences and insights
+- Discuss challenges and opportunities for gender equity in open source geospatial
+- Build solidarity and support networks across borders
+- Celebrate the contributions of women in our field
+
+All genders welcome! GeoChicas events are inclusive spaces for anyone who supports gender equity in the geospatial community.
+
+## Tickets
+
+This event operates on a pay-what-you-want model, making it accessible to all who wish to attend.
+
+[Get your tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/geochickas)

--- a/src/routes/program/ice-breaker/+page.svx
+++ b/src/routes/program/ice-breaker/+page.svx
@@ -1,0 +1,35 @@
+---
+title: Ice Breaker
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+  import MaritimeRoom from '$images/maritime-room.jpg?enhanced';
+</script>
+
+<enhanced:img src={MaritimeRoom} alt="Maritime Room View" />
+
+<Heading>Ice Breaker</Heading>
+
+**Tuesday 18th November from 6:30pm**
+
+Start your FOSS4G experience by connecting with fellow attendees at our welcoming Ice Breaker event! This is the perfect opportunity to meet new colleagues, reconnect with old friends, and begin building the collaborative spirit that makes FOSS4G conferences so special.
+
+## Venue
+
+Maritime Room
+New Zealand Maritime Museum
+Corner of Quay and Hobson Street
+Auckland
+
+The Maritime Room offers stunning harbour views and a relaxed atmosphere, providing the perfect backdrop for informal networking and conversation.
+
+## What to Expect
+
+This is a relaxed social event where you can:
+- Meet your fellow delegates in a casual setting
+- Enjoy complimentary canapes and drinks
+- Start making connections before the main conference begins
+- Explore the unique venue overlooking Auckland's waterfront
+
+Come as you are, grab a drink, and start your FOSS4G journey surrounded by the global open source geospatial community!

--- a/src/routes/program/movie-screening/+page.svx
+++ b/src/routes/program/movie-screening/+page.svx
@@ -1,0 +1,28 @@
+---
+title: Movie Screening
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+</script>
+
+<Heading>Movie Screening</Heading>
+
+**Monday 17th November, 6pm**
+
+Join us for a free movie screening at the AUT conference centre, room WG403.
+
+## I am the River, the River is Me
+
+> A canoe trip down the Whanganui River in New Zealand, led by a Māori elder, awakens
+> spiritual belief and practice, and becomes a call to action to draw closer to nature
+> and fight climate change through a fundamental value shift.
+
+This inspiring documentary explores the deep connection between people and nature, showcasing Māori perspectives on environmental stewardship and the revolutionary legal recognition of the Whanganui River as a living entity with its own rights.
+
+**Details:**
+- Free admission
+- Location: AUT Conference Centre, Room WG403
+- Duration: Approximately 90 minutes
+
+No registration required - simply turn up and enjoy!

--- a/src/routes/program/rangitoto/+page.svx
+++ b/src/routes/program/rangitoto/+page.svx
@@ -1,0 +1,47 @@
+---
+title: Rangitoto Day Trip
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+  import Rangitoto from '$images/rangitoto-island-auckland.jpeg?enhanced';
+  import Button from '$components/Button.svelte';
+  import Link from '$components/Link.svelte';
+</script>
+
+<enhanced:img src={Rangitoto} />
+
+<div class="flex flex-row justify-between">
+<Heading>Rangitoto Day Trip</Heading>
+<Button class="w-50" href="https://example.com">Purchase Tickets</Button>
+</div>
+
+**Saturday 22nd November – All Day (weather permitting)**
+
+Join fellow FOSS4G attendees for an unforgettable outdoor adventure to Rangitoto Island, Auckland's iconic volcanic cone! This is a perfect opportunity to connect with the community while exploring one of New Zealand's most unique natural landmarks, with breathtaking 360-degree views of Auckland and the Hauraki Gulf from the summit.
+
+**Trip Details:**
+- Departs from Downtown Ferry Terminal, 99 Quay St - Pier 13 at 9:15am
+- Returns to Auckland around 3:00pm
+- Cost: $60 per person - [Purchase tickets →](https://example.com)
+
+**What to bring:**
+- All food and water needed for the day
+- Sturdy, comfortable walking shoes
+- Sunblock, hat, and sun protection
+- Weather-appropriate clothing
+
+**Important - Pest-Free Requirements:**
+
+Rangitoto Island is a pest-free sanctuary. To help protect this precious ecosystem:
+- Ensure your footwear, clothing and bags are clean and free of soil and seeds
+- Your lunch must be packed in a rodent-proof/sealed container (e.g. hard plastic)
+- No open bags or boxes will be allowed onboard - everything you bring must be sealed or zipped closed
+
+**About the Walk:**
+
+The walk to the summit is moderately easy, featuring well-maintained stairs and gravel tracks. It's suitable for most fitness levels and takes approximately 1 hour to reach the top, where you'll be rewarded with stunning panoramic views.
+
+<Link href="https://www.fullers.co.nz/destinations-and-experiences/destinations/rangitoto-island/" target="_blank">Learn more about Rangitoto Island →</Link>
+
+

--- a/src/routes/program/rangitoto/+page.svx
+++ b/src/routes/program/rangitoto/+page.svx
@@ -13,7 +13,7 @@ title: Rangitoto Day Trip
 
 <div class="flex flex-row justify-between">
 <Heading>Rangitoto Day Trip</Heading>
-<Button class="w-50" href="https://example.com">Purchase Tickets</Button>
+<Button class="w-50" href="https://ti.to/osgeo-oceania/foss4g-2025/with/rangitoto-island-day-trip">Purchase Tickets</Button>
 </div>
 
 **Saturday 22nd November – All Day (weather permitting)**
@@ -23,7 +23,7 @@ Join fellow FOSS4G attendees for an unforgettable outdoor adventure to Rangitoto
 **Trip Details:**
 - Departs from Downtown Ferry Terminal, 99 Quay St - Pier 13 at 9:15am
 - Returns to Auckland around 3:00pm
-- Cost: $60 per person - [Purchase tickets →](https://example.com)
+- Cost: $60 per person - [Purchase tickets →](https://ti.to/osgeo-oceania/foss4g-2025/with/rangitoto-island-day-trip)
 
 **What to bring:**
 - All food and water needed for the day

--- a/src/routes/program/travel-grant-breakfast/+page.svx
+++ b/src/routes/program/travel-grant-breakfast/+page.svx
@@ -1,0 +1,33 @@
+---
+title: Travel Grant Program Breakfast
+---
+
+<script lang="ts">
+  import Heading from '$components/Heading.svelte';
+</script>
+
+<Heading>Travel Grant Program Breakfast</Heading>
+
+**Wednesday 19th November - Morning**
+
+A special breakfast gathering exclusively for our Travel Grant recipients, providing an opportunity to meet fellow grant awardees and connect with members of the FOSS4G organizing team.
+
+## Venue
+
+Scarecrow
+33 Victoria Street East
+Auckland Central
+
+Scarecrow is a charming local café in the heart of Auckland, known for its welcoming atmosphere and excellent breakfast menu.
+
+## About This Event
+
+This breakfast is our way of welcoming Travel Grant recipients to FOSS4G 2025. It's a chance to:
+- Meet other grant recipients from around the world
+- Connect with organizers and community leaders
+- Share your experiences and learn from others
+- Start building meaningful connections within the FOSS4G community
+
+**This event is available exclusively to Travel Grant recipients.** If you've received a travel grant, you should have received details about this breakfast in your grant notification.
+
+We look forward to meeting you and hearing about your journey to FOSS4G!


### PR DESCRIPTION
Each event now has it's own page for simpler linking, added all the necessary Rangitoto trip details

TODO:
 - [x] Update the purchase ticket link for Rangitoto when it's available

Header:

<img width="646" height="556" alt="Screenshot 2025-11-07 at 2 54 18 PM" src="https://github.com/user-attachments/assets/dd7e8d08-9341-4483-a183-30827ef30f6b" />


Rangitoto page:

<img width="1109" height="1428" alt="Screenshot 2025-11-07 at 2 55 46 PM" src="https://github.com/user-attachments/assets/97b7c9f1-0ec4-47a4-8ac8-f3da7f885666" />

