### PR TITLE
Add more events to the map, add road labels

### DIFF
--- a/src/data/pois.json
+++ b/src/data/pois.json
@@ -37,7 +37,7 @@
       },
       "geometry": {
         "type": "Point",
-        "coordinates": [174.7656241, -36.8533270]
+        "coordinates": [174.7656241, -36.853327]
       }
     },
     {
@@ -230,6 +230,36 @@
       "geometry": {
         "type": "Point",
         "coordinates": [174.766565, -36.849591]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 17,
+      "properties": {
+        "id": "icebreaker",
+        "name": "Maritime Room",
+        "event": "Icebreaker",
+        "date": "Nov 18",
+        "type": "event"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [174.7641304, -36.8423192]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 18,
+      "properties": {
+        "id": "rangitoto-island",
+        "name": "Pier 13",
+        "event": "Rangitoto Island Day Trip",
+        "date": "Nov 22",
+        "type": "event"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [174.7654545, -36.8425659]
       }
     }
   ]

--- a/src/lib/style/streets.ts
+++ b/src/lib/style/streets.ts
@@ -200,6 +200,47 @@ export default {
             ]
           }
         },
+        {
+          id: 'arterial-roads-label',
+          source: 'auckland',
+          'source-layer': 'roads-arterial',
+          type: 'symbol',
+          minzoom: 14,
+          layout: {
+            'text-field': ['get', 'name'],
+            'text-font': ['literal', ['BellTopo Sans Regular']],
+            'text-size': 16,
+            'symbol-placement': 'line',
+            'text-rotation-alignment': 'map',
+            'text-pitch-alignment': 'viewport'
+          },
+          paint: {
+            'text-color': '#666',
+            'text-halo-color': '#fff',
+            'text-halo-width': 2
+          }
+        },
+        {
+          id: 'minor-roads-label',
+          source: 'auckland',
+          'source-layer': 'roads',
+          type: 'symbol',
+          minzoom: 15,
+          filter: ['!', ['has', 'hway_num']],
+          layout: {
+            'text-field': ['get', 'name'],
+            'text-font': ['literal', ['BellTopo Sans Regular']],
+            'text-size': 12,
+            'symbol-placement': 'line',
+            'text-rotation-alignment': 'map',
+            'text-pitch-alignment': 'viewport'
+          },
+          paint: {
+            'text-color': '#888',
+            'text-halo-color': '#fff',
+            'text-halo-width': 1.5
+          }
+        },
 
         {
           id: 'venue-highlight',
@@ -606,7 +647,7 @@ export default {
           id: 'entrance',
           source: 'pois',
           type: 'symbol',
-          filter: ["==", ['get', 'type'], 'venue'],
+          filter: ['==', ['get', 'type'], 'venue'],
           minzoom: 16,
           maxzoom: 24,
           layout: {
@@ -615,7 +656,7 @@ export default {
             'icon-image': 'entrance',
             'icon-anchor': 'bottom',
             'text-font': ['literal', ['BellTopo Sans Regular']],
-            'text-field': "Entrance",
+            'text-field': 'Entrance',
             'text-offset': [0, 0.6],
 
             'icon-size': 0.3
@@ -623,9 +664,9 @@ export default {
           paint: {
             'text-halo-color': '#fff',
             'text-halo-width': 2,
-            'text-halo-blur': 1,
+            'text-halo-blur': 1
           }
-        },
+        }
       ]
     } as StyleSpecification;
   },


### PR DESCRIPTION
Adds Icebreaker and Rangitoto trip POIs

Also adds road labels - @rami-dv I think this is important for guests to orient themselves? It's fairly subtle as below and I think the map still looks great?

<img width="1071" height="642" alt="Screenshot 2025-11-10 at 5 18 04 PM" src="https://github.com/user-attachments/assets/d009c58d-00af-4c40-b758-24aa984ef41d" />
