### PR TITLE
Misc home tweaks

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -57,6 +57,10 @@
         {
           label: 'Terms and Conditions',
           url: '/attend/terms-and-conditions'
+        },
+        {
+          label: 'Sponsorship',
+          url: '/sponsorship'
         }
       ]
     },
@@ -157,10 +161,31 @@
       ]
     },
     {
-      label: 'Sponsorship',
-      url: '/sponsorship'
+      label: 'Schedule',
+      url: '/program/schedule'
     }
   ];
+
+  // Helper function to check if current page matches a menu item
+  function isMenuItemActive(menuItem: (typeof menuItems)[0]) {
+    // First check if any top-level menu item (without submenu) matches the current page
+    const topLevelMatch = menuItems.find(
+      (item) => !item.subMenu && item.url === page.route.id
+    );
+
+    // If there's a top-level match and this isn't it, don't highlight
+    if (topLevelMatch && topLevelMatch !== menuItem) return false;
+
+    // If current menu item is a direct match, highlight it
+    if (page.route.id === menuItem.url) return true;
+
+    // For items with submenus, check if any submenu item matches
+    if (menuItem.subMenu) {
+      return menuItem.subMenu.some((subItem) => page.route.id === subItem.url);
+    }
+
+    return false;
+  }
 </script>
 
 <div
@@ -180,7 +205,7 @@
             <div
               tabindex="0"
               role="button"
-              class={` hover:bg-success hover:text-primary flex items-center rounded-full border px-4 py-2 text-sm  font-light whitespace-nowrap transition-all duration-200 hover:cursor-pointer ${page.route.id === menuItem.url || menuItem.subMenu.some((subItem) => page.route.id === subItem.url) ? 'border-primary/50' : 'border-transparent'}`}
+              class={` hover:bg-success hover:text-primary flex items-center rounded-full border px-4 py-2 text-sm  font-light whitespace-nowrap transition-all duration-200 hover:cursor-pointer ${isMenuItemActive(menuItem) ? 'border-primary/50' : 'border-transparent'}`}
             >
               {menuItem.label}{#if menuItem.subMenu}
                 <span class="icon-[material-symbols-light--arrow-drop-down] -mx-1 h-5 w-5"></span>
@@ -207,7 +232,7 @@
           <Link
             aria-label={menuItem.label}
             href={menuItem.url}
-            class={` hover:bg-success hover:text-primary rounded-full border px-4 py-2 text-sm font-light whitespace-nowrap transition-all duration-200 ${page.route.id === menuItem.url ? 'border-primary/50' : 'border-transparent'}`}
+            class={` hover:bg-success hover:text-primary rounded-full border px-4 py-2 text-sm font-light whitespace-nowrap transition-all duration-200 ${isMenuItemActive(menuItem) ? 'border-primary/50' : 'border-transparent'}`}
             >{menuItem.label}
           </Link>
         {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,33 +13,6 @@
   import Card from '$components/Card.svelte';
   import Video from '$components/Video.svelte';
   import News from '$lib/news';
-
-  const whyAttends = [
-    {
-      number: '01',
-      title: 'cutting-edge-insights',
-      description:
-        'Gain firsthand knowledge from top geo experts and pioneers shaping the industry.'
-    },
-    {
-      number: '02',
-      title: 'hands-on learning',
-      description:
-        'Participate in interactive workshops, live demos, and deep-dive sessions to sharpen your skills.'
-    },
-    {
-      number: '03',
-      title: 'exclusive networking',
-      description:
-        'Connect with geo leaders, startups, and fellow professionals at community events.'
-    },
-    {
-      number: '04',
-      title: 'innovation showcase',
-      description:
-        'Explore geo solutions, from emerging startups to tech giants redefining the future.'
-    }
-  ];
 </script>
 
 <svelte:head>
@@ -204,8 +177,9 @@
           beautiful harbours, and fertile soils. They speak of the coming together of different iwi
           (tribes) to meet and trade.
         </div>
-        <div class="w-50">
+        <div class="flex flex-col gap-x-4 sm:w-[180px] sm:flex-row">
           <Button href="/map">Map</Button>
+          <Button href="/attend/nz-adventures">City Guide</Button>
         </div>
       </Card>
       <Card title="Our Conference Venue" color="secondary">
@@ -226,6 +200,10 @@
     <Video src="https://www.youtube-nocookie.com/embed/HNxqnUhL-yM?si=Z5-6exzf98KhoHZy" />
   </div>
 
+  <Heading>Keynote Speakers</Heading>
+
+  <Keynotes />
+
   <Heading>Agenda</Heading>
 
   <Agenda />
@@ -234,44 +212,9 @@
     <img src={Rangitoto} alt="Rangitoto" />
   </div>
 
-  <Heading>Keynote Speakers</Heading>
-
-  <Keynotes />
-
-  {#snippet whyAttendGrid(reason: (typeof whyAttends)[0], i: number)}
-    <div class="flex h-full w-full flex-1 py-1 text-white sm:p-2">
-      <div class="bg-primary h-full min-h-[240px] w-full overflow-clip rounded-4xl px-8 py-8">
-        <div class="pb-4 text-sm font-normal uppercase">{reason.title}</div>
-        <div
-          class="grid h-full grid-cols-2"
-          class:reverse-grid={i % 2 == 1}
-          class:sm:reverse-grid={i % 4 >= 2}
-        >
-          <div class="relative text-9xl font-medium">
-            <div class="text-secondary absolute -bottom-[20%]">
-              {reason.number}
-              <div class="from-primary absolute inset-0 bg-gradient-to-t to-transparent"></div>
-            </div>
-          </div>
-          <div class="-mt-[20%] mb-[20%] flex items-end justify-end text-sm">
-            {reason.description}
-          </div>
-        </div>
-      </div>
-    </div>
-  {/snippet}
-
-  <Heading class="mt-16 sm:mt-28">Why Attend?</Heading>
-
-  <div class="grid gap-2 pt-4 pb-8 sm:grid-cols-2 sm:gap-2 sm:pt-4 sm:pb-8">
-    {#each whyAttends as whyAttend, i}
-      {@render whyAttendGrid(whyAttend, i)}
-    {/each}
-  </div>
+  <Countdown label="Conference starts in:" time="2025-11-17T09:00:00+12:00" />
 
   <Heading class="mt-16 sm:mt-28">Register Now</Heading>
-
-  <Countdown label="Conference starts in:" time="2025-11-17T09:00:00+12:00" />
 
   <Heading size="sm" class="mt-8 sm:mt-14">Ticket Options</Heading>
 


### PR DESCRIPTION
  * Improve the header menu behaviour to only highlight the one relevant section button
  * Shuffle out the sponsorship info menu (no longer relvant), make schedule links simpler to find
  * home page: remove 'why attend' section and reorder home page for conference start

<img width="777" height="1157" alt="Screenshot 2025-11-12 at 9 13 41 PM" src="https://github.com/user-attachments/assets/10d0bd89-01d7-4e2a-af64-6d0450d5e97e" />
